### PR TITLE
update-rc.d: don't do anything if systemd.bbclass is inherited

### DIFF
--- a/meta/classes/update-rc.d.bbclass
+++ b/meta/classes/update-rc.d.bbclass
@@ -74,12 +74,15 @@ python populate_packages_prepend () {
         postrm += localdata.getVar('updatercd_postrm', True)
         d.setVar('pkg_postrm_%s' % pkg, postrm)
 
-    pkgs = d.getVar('INITSCRIPT_PACKAGES', True)
-    if pkgs == None:
-        pkgs = d.getVar('UPDATERCPN', True)
-        packages = (d.getVar('PACKAGES', True) or "").split()
-        if not pkgs in packages and packages != []:
-            pkgs = packages[0]
-    for pkg in pkgs.split():
-        update_rcd_package(pkg)
+    # If the systemd class has also been inherited, then don't do anything as
+    # the systemd units will override anything created by update-rc.d.
+    if not d.getVar("SYSTEMD_BBCLASS_ENABLED", True):
+        pkgs = d.getVar('INITSCRIPT_PACKAGES', True)
+        if pkgs == None:
+            pkgs = d.getVar('UPDATERCPN', True)
+            packages = (d.getVar('PACKAGES', True) or "").split()
+            if not pkgs in packages and packages != []:
+                pkgs = packages[0]
+        for pkg in pkgs.split():
+            update_rcd_package(pkg)
 }


### PR DESCRIPTION
Before doing real work in update-rc.d check if the systemd class has been inherited and don't do anything if it has.
