### PR TITLE
systemtap: Set FILESEXTRAPATHS_prepend rather than FILESPATH.

### DIFF
--- a/meta/recipes-kernel/systemtap/systemtap_git.inc
+++ b/meta/recipes-kernel/systemtap/systemtap_git.inc
@@ -4,11 +4,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 SRCREV = "48fa6b5e1d3e636c34cbd5650370e6f634efc294"
 PV = "1.8+git${SRCPV}"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/systemtap:"
 SRC_URI = "git://sourceware.org/git/systemtap.git;protocol=git \
            file://docproc-build-fix.patch \
           "
-
-FILESPATH = "${FILE_DIRNAME}/systemtap"
 
 SRC_URI[md5sum]    = "cb202866ed704c44a876d041f788bdee"
 SRC_URI[sha256sum] = "8ffe35caec0d937bd23fd78a3a8d94b58907cc0de0330b35e38f9f764815c459"


### PR DESCRIPTION
With the systemtap_git.inc file overriding FILESPATH additional layers
cannot append any new items to SRC_URI.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
