### PR TITLE
libaio: Remove QA warning: No GNU_HASH in the elf binary

### DIFF
--- a/meta/recipes-extended/libaio/libaio_0.3.109.bb
+++ b/meta/recipes-extended/libaio/libaio_0.3.109.bb
@@ -18,6 +18,10 @@ SRC_URI[sha256sum] = "bf4a457253cbaab215aea75cb6e18dc8d95bbd507e9920661ff9bdd288
 
 EXTRA_OEMAKE =+ "prefix=${prefix} includedir=${includedir} libdir=${libdir}"
 
+do_configure () {
+    sed -i 's#LINK_FLAGS=.*#LINK_FLAGS=$(LDFLAGS)#' src/Makefile
+}
+
 do_install () {
     oe_runmake install DESTDIR=${D}
 }


### PR DESCRIPTION
Update the LINK_FLAGS in the Makefile to remove warning:
QA Issue: No GNU_HASH in the elf binary

(From OE-Core rev: 07501f14121a1882f26de66b4ca991392ab45dff)

Signed-off-by: Christopher Larson chris_larson@mentor.com
Signed-off-by: Muhammad Shakeel muhammad_shakeel@mentor.com
Signed-off-by: Saul Wold sgw@linux.intel.com
Signed-off-by: Richard Purdie richard.purdie@linuxfoundation.org
(cherry picked from commit 6df2a6010882bee92c6af3ef575b4291570623c3)
