### PR TITLE
do not exit from postinstall script

### DIFF
--- a/meta/classes/gtk-icon-cache.bbclass
+++ b/meta/classes/gtk-icon-cache.bbclass
@@ -16,17 +16,16 @@ for icondir in $D/usr/share/icons/*/ ; do
 done
 EOF
     fi
-    exit 0
+else
+    # Update the pixbuf loaders in case they haven't been registered yet
+    GDK_PIXBUF_MODULEDIR=${libdir}/gdk-pixbuf-2.0/2.10.0/loaders gdk-pixbuf-query-loaders --update-cache
+
+    for icondir in /usr/share/icons/* ; do
+        if [ -d $icondir ] ; then
+            gtk-update-icon-cache -fqt  $icondir
+        fi
+    done
 fi
-
-# Update the pixbuf loaders in case they haven't been registered yet
-GDK_PIXBUF_MODULEDIR=${libdir}/gdk-pixbuf-2.0/2.10.0/loaders gdk-pixbuf-query-loaders --update-cache
-
-for icondir in /usr/share/icons/* ; do
-    if [ -d $icondir ] ; then
-        gtk-update-icon-cache -fqt  $icondir
-    fi
-done
 }
 
 gtk_icon_cache_postrm() {


### PR DESCRIPTION
Do not exit from postinstall script. If recipe appends postinstall scripts from different classes, than commands after exit statement are not executed.
