### PR TITLE
liburcu: disable compilation optimizatoin

### DIFF
--- a/meta/recipes-support/liburcu/liburcu_0.7.6.bb
+++ b/meta/recipes-support/liburcu/liburcu_0.7.6.bb
@@ -7,13 +7,14 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=0f060c30a27922ce9c0d557a639b4fa3 \
                     file://urcu.h;beginline=4;endline=32;md5=4de0d68d3a997643715036d2209ae1d9 \
                     file://urcu/uatomic/x86.h;beginline=4;endline=21;md5=220552f72c55b102f2ee35929734ef42"
 
-PR = "r0"
+PR = "r1"
 
 SRC_URI = "http://lttng.org/files/urcu/userspace-rcu-${PV}.tar.bz2"
 
 SRC_URI[md5sum] = "4c1ecb4bdcd43e36dfdffdd297023c8b"
 SRC_URI[sha256sum] = "71f2c0b75f3473e4d7aa6ac5111ca4d9cccccd5d131e87b53a07d35bd2c5900a"
 
+CFLAGS += "-O0"
 S = "${WORKDIR}/userspace-rcu-${PV}"
 CFLAGS_append_libc-uclibc = " -D_GNU_SOURCE"
 inherit autotools


### PR DESCRIPTION
profiled applications for user-space tracing were crashing with segmentation
violation. disabling optimization for liburcu solves this problem

http://jira.alm.mentorg.com:8080/browse/SB-1143

Signed-off-by: Fahad Usman fahad_usman@mentor.com
