### PR TITLE
bitbake: cache: appends change msg should be debug only

### DIFF
--- a/bitbake/lib/bb/cache.py
+++ b/bitbake/lib/bb/cache.py
@@ -527,8 +527,8 @@ class Cache(object):
                     return False
 
         if appends != info_array[0].appends:
-            logger.debug(2, "Cache: appends for %s changed", fn)
-            bb.note("%s to %s" % (str(appends), str(info_array[0].appends)))
+            logger.debug(2, "Cache: appends for %s changed from %s to %s",
+                         fn, info_array[0].appends, appends))
             self.remove(fn)
             return False
 


### PR DESCRIPTION
This quiets the odd message shown to the user every time the appends for
a given recipe change. It has no context, since the message before it was
a debug message.

Signed-off-by: Christopher Larson chris_larson@mentor.com
(cherry picked from commit 178db8e4016f5de86645683c159a6aa94c72547b)

Signed-off-by: Michael Brown mw_brown@mentor.com
