### PR TITLE
Backported lttng 2.2.0 from master branch

### DIFF
--- a/meta/recipes-kernel/lttng-2.0/babeltrace_1.1.1.bb
+++ b/meta/recipes-kernel/lttng-2.0/babeltrace_1.1.1.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Babeltrace - Trace Format Babel Tower"
 DESCRIPTION = "Babeltrace provides trace read and write libraries in host side, as well as a trace converter, which used to convert LTTng 2.0 traces into human-readable log."
 HOMEPAGE = "http://www.efficios.com/babeltrace/"
-BUGTRACKER = "n/a"
+BUGTRACKER = "https://bugs.lttng.org/projects/babeltrace"
 
 LICENSE = "MIT & GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=76ba15dd76a248e1dd526bca0e2125fa"
@@ -10,14 +10,13 @@ inherit autotools
 
 DEPENDS = "glib-2.0 util-linux popt"
 
-SRCREV = "9eaf25433864cefc40242e0257a0177ef4515930"
-PV = "1.0+git${SRCPV}"
-PR = "r0"
+SRCREV = "a386e24609752742b100120db6798d311fab512a"
+PV = "1.1+git${SRCPV}"
 
 SRC_URI = "git://git.efficios.com/babeltrace.git;protocol=git"
 
 S = "${WORKDIR}/git"
 
 do_configure_prepend () {
-	${S}/bootstrap
+	( cd ${S}; ${S}/bootstrap )
 }

--- a/meta/recipes-kernel/lttng-2.0/lttng-modules/lttng-modules-replace-KERNELDIR-with-KERNEL_SRC.patch
+++ b/meta/recipes-kernel/lttng-2.0/lttng-modules/lttng-modules-replace-KERNELDIR-with-KERNEL_SRC.patch
@@ -7,35 +7,75 @@ build and install lttng-modules, we do this replacement for
 it as-is.
 
 Signed-off-by: Zumeng Chen <zumeng.chen@windriver.com>
----
- Makefile |    7 +++----
- 1 files changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 5ac13d7..25caad5 100644
+index a9d1cb1..c1b65b9 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -38,17 +38,16 @@ obj-m += lib/
- endif
-
- else
+@@ -43,19 +43,19 @@ obj-m += lib/
+ endif # CONFIG_TRACEPOINTS
+ 
+ else # KERNELRELEASE
 -	KERNELDIR ?= /lib/modules/$(shell uname -r)/build
++	KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
  	PWD := $(shell pwd)
  	CFLAGS = $(EXTCFLAGS)
-
+ 
  default:
 -	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 +	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
-
+ 
  modules_install:
 -	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
 +	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
-
+ 
  clean:
 -	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
 +	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
-
+ 
+ %.i: %.c
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) $@
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) $@
+ endif # KERNELRELEASE
+diff --git a/README b/README
+index 8c5dd46..6bd3334 100644
+--- a/README
++++ b/README
+@@ -27,8 +27,8 @@ access to your full kernel source tree), and use:
+ If you need to specify the target directory to the kernel you want to build
+ against, use:
+ 
+-% KERNELDIR=path_to_kernel_dir make
+-# KERNELDIR=path_to_kernel_dir make modules_install
++% KERNEL_SRC=path_to_kernel_dir make
++# KERNEL_SRC=path_to_kernel_dir make modules_install
+ # depmod -a kernel_version
+ 
+ Use lttng-tools to control the tracer. LTTng tools should automatically load
+diff --git a/probes/Makefile b/probes/Makefile
+index 225803c..3449866 100644
+--- a/probes/Makefile
++++ b/probes/Makefile
+@@ -212,18 +212,18 @@ endif
  endif
--- 
-1.7.5.4
-
+ 
+ else
+-	KERNELDIR ?= /lib/modules/$(shell uname -r)/build
++	KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
+ 	PWD := $(shell pwd)
+ 	CFLAGS = $(EXTCFLAGS)
+ 
+ default:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
+ 
+ modules_install:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
+ 	/sbin/depmod -a
+ 
+ clean:
+-	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
+ 
+ endif

--- a/meta/recipes-kernel/lttng-2.0/lttng-modules_2.2.0.bb
+++ b/meta/recipes-kernel/lttng-2.0/lttng-modules_2.2.0.bb
@@ -10,9 +10,8 @@ DEPENDS = "virtual/kernel"
 
 inherit module
 
-SRCREV = "b374c356eb4827b68754d68adc0f1c94b5de9faa"
-PV = "2.1.1"
-PR = "r0"
+SRCREV = "1b26381c19dd2d9fa41f52d8dc13b15b8dd32c7c"
+PV = "2.2.0"
 
 SRC_URI = "git://git.lttng.org/lttng-modules.git;protocol=git \
            file://lttng-modules-replace-KERNELDIR-with-KERNEL_SRC.patch"
@@ -22,3 +21,14 @@ export KERNEL_SRC="${STAGING_KERNEL_DIR}"
 
 
 S = "${WORKDIR}/git"
+
+do_install_append() {
+	# Delete empty directories to avoid QA failures if no modules were built
+	find ${D}/lib -depth -type d -empty -exec rmdir {} \;
+}
+
+python do_package_prepend() {
+    if not os.path.exists(os.path.join(d.getVar('D', True), 'lib/modules')):
+        bb.warn("%s: no modules were created; this may be due to CONFIG_TRACEPOINTS not being enabled in your kernel." % d.getVar('PN', True))
+}
+

--- a/meta/recipes-kernel/lttng-2.0/lttng-tools_2.2.0.bb
+++ b/meta/recipes-kernel/lttng-2.0/lttng-tools_2.2.0.bb
@@ -11,9 +11,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=01d7fc4496aacf37d90df90b90b0cac1 \
 
 DEPENDS = "liburcu popt lttng2-ust"
 
-SRCREV = "917f768512b5d336d553b801f6c5308d90252a89"
-PV = "2.1.0"
-PR = "r0"
+SRCREV = "eff0b2c38d24092c41bbb51926ac4e3b8c6acb83"
+PV = "v2.2.0"
 
 SRC_URI = "git://git.lttng.org/lttng-tools.git;protocol=git"
 

--- a/meta/recipes-kernel/lttng-2.0/lttng2-ust/build-Fix-out-of-tree-build.patch
+++ b/meta/recipes-kernel/lttng-2.0/lttng2-ust/build-Fix-out-of-tree-build.patch
@@ -1,0 +1,28 @@
+From d5a822fbeaec69e86c6af1f0ab8db0ff030f6678 Mon Sep 17 00:00:00 2001
+From: Otavio Salvador <otavio@ossystems.com.br>
+Date: Tue, 2 Jul 2013 10:25:06 -0300
+Subject: [PATCH] build: Fix out-of-tree build
+
+To allow out-of-tree build, we need to include top_buildir in include
+directories or the generated config header won't be found.
+
+Upstream-Status: Pending
+
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+---
+ liblttng-ust-comm/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/liblttng-ust-comm/Makefile.am b/liblttng-ust-comm/Makefile.am
+index 2ae997c..065dbbf 100644
+--- a/liblttng-ust-comm/Makefile.am
++++ b/liblttng-ust-comm/Makefile.am
+@@ -1,4 +1,4 @@
+-AM_CPPFLAGS = -I$(top_srcdir)/include
++AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
+ 
+ noinst_LTLIBRARIES = liblttng-ust-comm.la
+ 
+-- 
+1.8.3.1
+

--- a/meta/recipes-kernel/lttng-2.0/lttng2-ust_2.2.0.bb
+++ b/meta/recipes-kernel/lttng-2.0/lttng2-ust_2.2.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Linux Trace Toolkit Userspace Tracer 2.0"
 DESCRIPTION = "The LTTng UST 2.0 package contains the userspace tracer library to trace userspace codes."
-HOMEPAGE = "http://lttng.org/lttng2.0"
-BUGTRACKER = "n/a"
+HOMEPAGE = "http://lttng.org/ust"
+BUGTRACKER = "https://bugs.lttng.org/projects/lttng-ust"
 
 LICENSE = "LGPLv2.1+ & BSD & GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c963eb366b781252b0bf0fdf1624d9e9 \
@@ -12,12 +12,13 @@ inherit autotools
 
 DEPENDS = "liburcu util-linux"
 
-SRCREV = "05356aa2a4dca0bc9bfd716d2d6723e3941851dc"
-PV = "2.1.1"
-PR = "r0"
+SRCREV = "cfaee541fea7f5760b5501913c6902f5e4da9dba"
+PV = "2.2.0"
+PE = "2"
 
 SRC_URI = "git://git.lttng.org/lttng-ust.git;protocol=git \
 	   file://depends-liblttng-ust-tracepoin.patch \
+	   file://build-Fix-out-of-tree-build.patch \
 	   "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Author: Otavio Salvador otavio@ossystems.com.br
    babeltrace: Update to 1.1.1 based release
    lttng-ust: Update to 2.2.0 based release
    lttng-modules: Update to 2.2.0 based release
    lttng-tools: Update to 2.2.0 based release

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
