### PR TITLE
libmusicbrainz: Explicitly link with libpthread.a

### DIFF
--- a/meta/recipes-multimedia/musicbrainz/libmusicbrainz_3.0.3.bb
+++ b/meta/recipes-multimedia/musicbrainz/libmusicbrainz_3.0.3.bb
@@ -12,7 +12,7 @@ SRC_URI = "http://ftp.musicbrainz.org/pub/musicbrainz/${BPN}-${PV}.tar.gz \
            file://fix_build_issue_for_gcc_4.5.0.patch \
            file://allow-libdir-override.patch "
 
-LDFLAGS_prepend_libc-uclibc = " -lpthread "
+LDFLAGS_prepend = " -lpthread "
 
 SRC_URI[md5sum] = "f4824d0a75bdeeef1e45cc88de7bb58a"
 SRC_URI[sha256sum] = "7fd459a9fd05be9faec60a9a21caa9a1e9fda03147d58d8c7c95f33582a738c5"


### PR DESCRIPTION
Workaround the issue discussed here:
   http://sourceware.org/bugzilla/show_bug.cgi?id=15126

Signed-off-by: Drew Moseley drew_moseley@mentor.com
