### PR TITLE
python-pygtk: fix parallel compile issue

### DIFF
--- a/meta/recipes-devtools/python/python-pygtk/update-dependences-of-defs.c.patch
+++ b/meta/recipes-devtools/python/python-pygtk/update-dependences-of-defs.c.patch
@@ -1,0 +1,38 @@
+From dc024e9079bbffbb44436ba3e70a758ebad5520f Mon Sep 17 00:00:00 2001
+From: "Song.Li" <Song.Li@windriver.com>
+Date: Sat, 5 Jan 2013 14:55:59 +0800
+Subject: [PATCH] update dependences of defs.c in Makefile.am
+
+In gtk/Makefile.am, defs.c should dependes on gdk-types.defs and
+gtk-types.defs, otherwise it fails occasionally when parallel compile.
+The error message:
+"IOError: [Errno 2] No such file or directory: 'gtk-types.defs'"
+
+Add them to dependences of defs.c to fix this issue.
+
+Upstream-Status: Submitted
+https://bugzilla.gnome.org/show_bug.cgi?id=702706
+
+Signed-off-by: Song.Li <Song.Li@windriver.com>
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+
+---
+ gtk/Makefile.am |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gtk/Makefile.am b/gtk/Makefile.am
+index 7bb5d0c..91826cb 100644
+--- a/gtk/Makefile.am
++++ b/gtk/Makefile.am
+@@ -289,7 +289,7 @@ if HAVE_GIO_TYPES_DEFS
+ extra_codegen_args += --register $(PYGOBJECT_DEFSDIR)/gio-types.defs
+ endif
+ 
+-.defs.c: 
++.defs.c: gdk-types.defs gtk-types.defs
+ 	($(PYTHON) $(CODEGENDIR)/codegen.py \
+ 	   $(PYGTK_CODEGEN_DEFINES) \
+ 	    -I $(srcdir) \
+-- 
+1.7.9.5
+

--- a/meta/recipes-devtools/python/python-pygtk_2.24.0.bb
+++ b/meta/recipes-devtools/python/python-pygtk_2.24.0.bb
@@ -14,7 +14,8 @@ SRC_URI = "ftp://ftp.gnome.org/pub/gnome/sources/pygtk/2.24/${SRCNAME}-${PV}.tar
            file://fix-gtkunixprint.patch \
            file://prevent_to_get_display_during_import.patch \
            file://nodocs.patch \
-           file://acinclude.m4"
+           file://acinclude.m4 \
+           file://update-dependences-of-defs.c.patch"
 
 SRC_URI[md5sum] = "a1051d5794fd7696d3c1af6422d17a49"
 SRC_URI[sha256sum] = "cd1c1ea265bd63ff669e92a2d3c2a88eb26bcd9e5363e0f82c896e649f206912"


### PR DESCRIPTION
defs.c dependes on gdk-types.defs and gtk-types.defs. When parallel compile,
it may fails with:
"IOError: [Errno 2] No such file or directory: 'gtk-types.defs'"

Add them to dependences of defs.c to fix this issue.

Signed-off-by: Kai Kang kai.kang@windriver.com
