### PR TITLE
opkg: fix for MEIP-275

### DIFF
--- a/meta/recipes-devtools/opkg/opkg.inc
+++ b/meta/recipes-devtools/opkg/opkg.inc
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f \
                     file://src/opkg-cl.c;beginline=1;endline=20;md5=321f658c3f6b6c832e25c8850b5dffba"
 
 PE = "1"
-INC_PR = "r10"
+INC_PR = "r11"
 
 FILESDIR = "${@os.path.dirname(d.getVar('FILE',1))}/opkg"
 
@@ -49,6 +49,10 @@ FILES_libopkg = "${libdir}/*.so.* ${localstatedir}/lib/opkg/"
 # We need to create the lock directory
 do_install_append() {
 	install -d ${D}${localstatedir}/lib/opkg
+       if [[ "${IMAGE_FEATURES}" == *"read-only-rootfs"* ]]
+       then
+           install -D -m 0644 ${WORKDIR}/02-opkg-ro-rootfs-volatile.conf ${D}${sysconfdir}/tmpfiles.d/02-opkg-ro-rootfs-volatile.conf
+       fi
 }
 
 pkg_postinst_${PN} () {

--- a/meta/recipes-devtools/opkg/opkg/0011-write_lock_file-to-rw-volatile-path.patch
+++ b/meta/recipes-devtools/opkg/opkg/0011-write_lock_file-to-rw-volatile-path.patch
@@ -1,0 +1,13 @@
+--- a/libopkg/opkg_conf.c	2013-08-26 21:29:00.330114975 +0530
++++ b/libopkg/opkg_conf.c	2013-08-27 00:28:08.908012435 +0530
+@@ -511,7 +511,9 @@
+ 	if (conf->offline_root)
+ 		sprintf_alloc (&lock_file, "%s/%s", conf->offline_root, OPKGLOCKFILE);
+ 	else
+-		sprintf_alloc (&lock_file, "%s", OPKGLOCKFILE);
++		// In case read-only-rootfs configured, lock file should be created on rw volatile path
++		// sprintf_alloc (&lock_file, "%s", OPKGLOCKFILE);
++		sprintf_alloc (&lock_file, "%s", "/var/volatile/opkg/lock");
+ 
+ 	lock_fd = creat(lock_file, S_IRUSR | S_IWUSR | S_IRGRP);
+ 	if (lock_fd == -1) {

--- a/meta/recipes-devtools/opkg/opkg/02-opkg-ro-rootfs-volatile.conf
+++ b/meta/recipes-devtools/opkg/opkg/02-opkg-ro-rootfs-volatile.conf
@@ -1,0 +1,1 @@
+d		/var/volatile/opkg		-	-	-	-

--- a/meta/recipes-devtools/opkg/opkg_svn.bb
+++ b/meta/recipes-devtools/opkg/opkg_svn.bb
@@ -11,7 +11,9 @@ SRC_URI = "svn://opkg.googlecode.com/svn;module=trunk;protocol=http \
   file://0008-select_higher_version.patch \
   file://0009-pkg_depends-fix-version-constraints.patch \
   file://0010-pkg_depends-fix-version_constraints_satisfied.patch \
+  file://0011-write_lock_file-to-rw-volatile-path.patch \
   file://opkg-no-sync-offline.patch \
+  file://02-opkg-ro-rootfs-volatile.conf \
 "
 
 S = "${WORKDIR}/trunk"
@@ -19,4 +21,4 @@ S = "${WORKDIR}/trunk"
 SRCREV = "633"
 PV = "0.1.8+svnr${SRCPV}"
 
-PR = "${INC_PR}.7"
+PR = "${INC_PR}.8"


### PR DESCRIPTION
Change location of lock file from /var/lib/opkg/lock to
/var/volatile/opkg/lock so that it can work with ro rootfs.

Signed-off-by: Sanjeev Chugh sanjeev_chugh@mentor.com
