### PR TITLE
opkg: MEIP-275- re-work on opkg lock file patch

### DIFF
--- a/meta/recipes-devtools/opkg/opkg_svn.bb
+++ b/meta/recipes-devtools/opkg/opkg_svn.bb
@@ -11,9 +11,9 @@ SRC_URI = "svn://opkg.googlecode.com/svn;module=trunk;protocol=http \
   file://0008-select_higher_version.patch \
   file://0009-pkg_depends-fix-version-constraints.patch \
   file://0010-pkg_depends-fix-version_constraints_satisfied.patch \
-  file://0011-write_lock_file-to-rw-volatile-path.patch \
   file://opkg-no-sync-offline.patch \
   file://02-opkg-ro-rootfs-volatile.conf \
+  ${@base_contains('IMAGE_FEATURES', 'read-only-rootfs', 'file://0011-write_lock_file-to-rw-volatile-path.patch', '', d)} \
 "
 
 S = "${WORKDIR}/trunk"
@@ -21,4 +21,4 @@ S = "${WORKDIR}/trunk"
 SRCREV = "633"
 PV = "0.1.8+svnr${SRCPV}"
 
-PR = "${INC_PR}.8"
+PR = "${INC_PR}.9"


### PR DESCRIPTION
Apply opkg lock file patch only when ro rootfs is configured

Signed-off-by: Sanjeev Chugh sanjeev_chugh@mentor.com
