### PR TITLE
toaster: Remove check done on pkgnmap

### DIFF
--- a/bitbake/lib/bb/ui/buildinfohelper.py
+++ b/bitbake/lib/bb/ui/buildinfohelper.py
@@ -511,9 +511,8 @@ class ORMWrapper(object):
         errormsg = ""
         for p in packagedict:
             searchname = p
-            if p in pkgpnmap:
-                if 'OPKGN' in pkgpnmap[p].keys():
-                    searchname = pkgpnmap[p]['OPKGN']
+            if 'OPKGN' in pkgpnmap[p].keys():
+                searchname = pkgpnmap[p]['OPKGN']
 
             packagedict[p]['object'], created = Package.objects.get_or_create( build = build_obj, name = searchname )
             if created or packagedict[p]['object'].size == -1:    # save the data anyway we can, not just if it was not created here; bug [YOCTO #6887]


### PR DESCRIPTION
This check has already been added by Michael Wood in commit
http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=41286f473086ef025d075bae1bb03a2929d1bfca
So removing that change.

Signed-off-by: Sujith H <Sujith_Haridasan@mentor.com>