### PR TITLE
toaster: built_recipe shouldn't be None

### DIFF
--- a/bitbake/lib/bb/ui/buildinfohelper.py
+++ b/bitbake/lib/bb/ui/buildinfohelper.py
@@ -302,6 +302,11 @@ class ORMWrapper(object):
         if created and must_exist:
             raise NotExisting("Recipe object created when expected to exist", recipe_information)
 
+        if built_recipe is None:
+            built_recipe, c = self._cached_get_or_create(Recipe,
+                    layer_version=built_layer,
+                    file_path=recipe_information['file_path'],
+                    pathflags = recipe_information['pathflags'])
         return built_recipe
 
     def get_update_layer_version_object(self, build_obj, layer_obj, layer_version_information):


### PR DESCRIPTION
built_recipe shouldn't be None. If it becomes None,
then toaster fails. With this change I have verified
with mx6q. console-image was successfully built.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>