### PR TITLE
Shallow rework

### DIFF
--- a/bitbake/lib/bb/fetch2/git.py
+++ b/bitbake/lib/bb/fetch2/git.py
@@ -274,7 +274,7 @@ class Git(FetchMethod):
             if not os.path.exists(ud.fullshallow):
                 if os.path.islink(ud.fullshallow):
                     os.unlink(ud.fullshallow)
-                tempdir = tempfile.mkdtemp()
+                tempdir = tempfile.mkdtemp(dir=d.getVar('DL_DIR', True))
                 shallowclone = os.path.join(tempdir, 'git')
                 try:
                     repourl = self._get_repo_url(ud)

--- a/bitbake/lib/bb/fetch2/git.py
+++ b/bitbake/lib/bb/fetch2/git.py
@@ -182,7 +182,7 @@ class Git(FetchMethod):
 
                 if shallow:
                     tarballname = tarballname + "_" + shallow
-            ud.shallowtarball = 'git2_%s.tar.gz' % tarballname
+            ud.shallowtarball = 'gitshallow_%s.tar.gz' % tarballname
             ud.fullshallow = os.path.join(dl_dir, ud.shallowtarball)
             ud.mirrortarballs = [ud.shallowtarball, ud.mirrortarball]
 


### PR DESCRIPTION
This revamps how shallow repositories are constructed in a way that prevents the shallow commits being bypassed, which means we *know* the repository will be as small as we expect, and it allows us to also keep all branches in the repo when we choose to, which means we can properly support linux-yocto. This fixes our shallow use for qemu once we enable it appropriately in meta-mentor.