### PR TITLE
bitbake: fetch2: compare localpaths, not methods

### DIFF
--- a/bitbake/lib/bb/fetch2/__init__.py
+++ b/bitbake/lib/bb/fetch2/__init__.py
@@ -947,7 +947,7 @@ def try_mirror_url(fetch, origud, ud, ld, check = False):
         # We may be obtaining a mirror tarball which needs further processing by the real fetcher
         # If that tarball is a local file:// we need to provide a symlink to it
         dldir = ld.getVar("DL_DIR", True)
-        if origud.method != ud.method:
+        if os.path.basename(ud.localpath) != os.path.basename(origud.localpath):
             # Create donestamp in old format to avoid triggering a re-download
             bb.utils.mkdirhier(os.path.dirname(ud.donestamp))
             open(ud.donestamp, 'w').close()


### PR DESCRIPTION
We only want to trigger the mirror tarball handling if the basenames don't
match up. If we do so based solely on method, then valid cases where a file is
fetched from a different method than the base url will trigger that logic.

In the case where an http file is found via a file mirror, this was causing
the http fetcher to be run to process the nonexistent mirror tarball,
resulting in an attempt to download from upstream when we already have the
file.

JIRA: SB-6156