### PR TITLE
Ensure that no reflogs are keeping objects around

### DIFF
--- a/bitbake/lib/bb/fetch2/git.py
+++ b/bitbake/lib/bb/fetch2/git.py
@@ -400,6 +400,7 @@ class Git(FetchMethod):
                         continue
                     queue.append(merge_base)
 
+        runfetchcmd('%s reflog expire --expire-unreachable=now --all' % gitcmd, d)
         runfetchcmd('%s repack -ad' % gitcmd, d)
         runfetchcmd('%s prune-packed' % gitcmd, d)
 

--- a/bitbake/lib/bb/fetch2/git.py
+++ b/bitbake/lib/bb/fetch2/git.py
@@ -346,6 +346,7 @@ class Git(FetchMethod):
             shallow_branches = None
         else:
             runfetchcmd("%s for-each-ref --format='%%(refname)' | xargs -n 1 %s update-ref -d" % (gitcmd, gitcmd), d)
+            runfetchcmd('%s update-ref -d HEAD' % gitcmd, d)
             shallow_branches = []
             for name, (shallow, revision, branch) in branchinfo.iteritems():
                 if nobranch:


### PR DESCRIPTION
This shrinks linux-xlnx the way it should be.

JIRA: SB-6220