### PR TITLE
bb.fetch2.{git, hg}: force tarball generation when repo is re-fetched

### DIFF
--- a/bitbake/lib/bb/fetch2/git.py
+++ b/bitbake/lib/bb/fetch2/git.py
@@ -285,6 +285,7 @@ class Git(FetchMethod):
             runfetchcmd("%s pack-redundant --all | xargs -r rm" % ud.basecmd, d)
             try:
                 os.unlink(ud.fullmirror)
+                ud.write_tarballs = "1"
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
                     raise

--- a/bitbake/lib/bb/fetch2/hg.py
+++ b/bitbake/lib/bb/fetch2/hg.py
@@ -190,6 +190,7 @@ class Hg(FetchMethod):
                 runfetchcmd(pullcmd, d)
                 try:
                     os.unlink(ud.fullmirror)
+                    ud.write_tarballs = "1"
                 except OSError as exc:
                     if exc.errno != errno.ENOENT:
                         raise


### PR DESCRIPTION
The fetcher expects to see a tarball at the end of fetching
if one is found under source mirrors. With the current
logic, if the fetched scm tarball does not contain the
required hashes the repo is re-fetched and the downloaded
tarball is deleted. This causes the fetcher to fail
as it looks for the tarball and only passes in such cases
when the BB_GENERATE_MIRROR_TARBALLS is set.
We now force generation of tarball irrespective of
BB_GENERATE_MIRROR_TARBALLS in cases where the
repo is re-fetched.

Signed-off-by: Awais Belal <awais_belal@mentor.com>