### PR TITLE
wic: don't throw away our created swap partition

### DIFF
--- a/scripts/lib/wic/kickstart/custom_commands/partition.py
+++ b/scripts/lib/wic/kickstart/custom_commands/partition.py
@@ -173,6 +173,7 @@ class Wic_PartData(FC4_PartData):
             if self.fstype and self.fstype == "swap":
                 self.prepare_swap_partition(cr_workdir, oe_builddir,
                                             native_sysroot)
+                self.source_file = "%s/fs.%s" % (cr_workdir, self.fstype)
             elif self.fstype:
                 rootfs = "%s/fs_%s.%s.%s" % (cr_workdir, self.label,
                                              self.lineno, self.fstype)


### PR DESCRIPTION
We were creating the partition, mkswap'ing it, and then not dd'ing it into
place in the final image, as source_file wasn't being set for swap partitions.
This would result in a swap partition that couldn't be enabled on target until
mkswap was run.

Upstream: git://git.openembedded.org/openembedded-core
Commit-ID: 7580942a66f84c2120763c2d9665e2cec8e25138

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
Signed-off-by: Ross Burton <ross.burton@intel.com>
Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>