### PR TITLE
staging.bbclass: make already-stripped can be skipped

### DIFF
--- a/meta/classes/staging.bbclass
+++ b/meta/classes/staging.bbclass
@@ -127,7 +127,10 @@ python sysroot_strip () {
                     elf_file = isELF(file)
                     if elf_file & 1:
                         if elf_file & 2:
-                            bb.warn("File '%s' from %s was already stripped, this will prevent future debugging!" % (file[len(dvar):], pn))
+                            if 'already-stripped' in (d.getVar('INSANE_SKIP_' + pn, True) or "").split():
+                                bb.note("Skipping file %s from %s for already-stripped QA test" % (file[len(dvar):], pn))
+                            else:
+                                bb.warn("File '%s' from %s was already stripped, this will prevent future debugging!" % (file[len(dvar):], pn))
                             continue
 
                         if s.st_ino in inodes:


### PR DESCRIPTION
Add a check like what we does in package.bbclass
so that the already-stripped QA test can be skipped.

(From OE-Core rev: 2262fdb256954b22dadb2f7c6922e6046c269742)

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
Signed-off-by: Ross Burton <ross.burton@intel.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>