### PR TITLE
wic: write startup.nsh for /EFI/BOOT/boot*.efi

### DIFF
--- a/scripts/lib/wic/plugins/source/bootimg-efi.py
+++ b/scripts/lib/wic/plugins/source/bootimg-efi.py
@@ -24,6 +24,7 @@
 # Tom Zanussi <tom.zanussi (at] linux.intel.com>
 #
 
+import glob
 import os
 import shutil
 
@@ -196,6 +197,12 @@ class BootimgEFIPlugin(SourcePlugin):
                 msger.error("unrecognized bootimg-efi loader: %s" % source_params['loader'])
         except KeyError:
             msger.error("bootimg-efi requires a loader, none specified")
+
+        # Auto startup for /EFI/BOOT/boot*.efi
+        bootfiles = glob.glob('%s/EFI/BOOT/boot*.efi' % hdddir)
+        if bootfiles and len(bootfiles) == 1:
+            with open('%s/startup.nsh' % hdddir, 'w') as f:
+                f.write('fs0:\\EFI\\BOOT\\%s\n' % os.path.basename(bootfiles[0]))
 
         du_cmd = "du -bks %s" % hdddir
         out = exec_cmd(du_cmd)


### PR DESCRIPTION
It's useful to set up automatic boot rather than having to type the
commands into the EFI boot prompt every time. For non-wic, bootimg sets
this up, but only for ISO, and of course that doesn't apply to wic. This
mirrors the behavior of the mkefidisk.sh script.

[YOCTO #9384]
JIRA: SB-7056
