### PR TITLE
update_gio_module_cache: fix host user contamination

### DIFF
--- a/scripts/postinst-intercepts/update_gio_module_cache
+++ b/scripts/postinst-intercepts/update_gio_module_cache
@@ -5,3 +5,5 @@ set -e
 PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D${libdir}:$D${base_libdir} \
         $D${libexecdir}/${binprefix}gio-querymodules $D${libdir}/gio/modules/
 
+chown root:root $D${libdir}/gio/modules/giomodule.cache
+


### PR DESCRIPTION
update_gio_module_cache intercept creates file:
$D${libdir}/gio/modules/giomodule.cache

Change ownership of this file to root:root to avoid user contamination
by host.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>