### PR TITLE
Rework how startup.nsh is written

### DIFF
--- a/meta/classes/grub-efi.bbclass
+++ b/meta/classes/grub-efi.bbclass
@@ -45,6 +45,8 @@ efi_populate() {
 		GRUB_IMAGE="bootx64.efi"
 	fi
 	install -m 0644 ${DEPLOY_DIR_IMAGE}/${GRUB_IMAGE} ${DEST}${EFIDIR}
+	EFIPATH=$(echo "${EFIDIR}" | sed 's/\//\\/g')
+	printf 'fs0:%s\%s\n' "$EFIPATH" "$GRUB_IMAGE" >${DEST}/startup.nsh
 
 	install -m 0644 ${GRUB_CFG} ${DEST}${EFIDIR}/grub.cfg
 }

--- a/meta/classes/gummiboot.bbclass
+++ b/meta/classes/gummiboot.bbclass
@@ -34,6 +34,8 @@ efi_populate() {
         install -d ${DEST}/loader
         install -d ${DEST}/loader/entries
         install -m 0644 ${DEPLOY_DIR_IMAGE}/${EFI_IMAGE} ${DEST}${EFIDIR}/${DEST_EFI_IMAGE}
+        EFIPATH=$(echo "${EFIDIR}" | sed 's/\//\\/g')
+	printf 'fs0:%s\%s\n' "$EFIPATH" "$DEST_EFI_IMAGE" >${DEST}/startup.nsh
         install -m 0644 ${GUMMIBOOT_CFG} ${DEST}/loader/loader.conf
         for i in ${GUMMIBOOT_ENTRIES}; do
             install -m 0644 ${i} ${DEST}/loader/entries

--- a/scripts/lib/wic/plugins/source/bootimg-efi.py
+++ b/scripts/lib/wic/plugins/source/bootimg-efi.py
@@ -197,6 +197,11 @@ class BootimgEFIPlugin(SourcePlugin):
         except KeyError:
             msger.error("bootimg-efi requires a loader, none specified")
 
+        startup = os.path.join(bootimg_dir, "startup.nsh")
+        if os.path.exists(startup):
+            cp_cmd = "cp %s %s/" % (startup, hdddir)
+            exec_cmd(cp_cmd, True)
+
         du_cmd = "du -bks %s" % hdddir
         out = exec_cmd(du_cmd)
         blocks = int(out.split()[0])

--- a/scripts/lib/wic/plugins/source/bootimg-efi.py
+++ b/scripts/lib/wic/plugins/source/bootimg-efi.py
@@ -24,7 +24,6 @@
 # Tom Zanussi <tom.zanussi (at] linux.intel.com>
 #
 
-import glob
 import os
 import shutil
 
@@ -197,12 +196,6 @@ class BootimgEFIPlugin(SourcePlugin):
                 msger.error("unrecognized bootimg-efi loader: %s" % source_params['loader'])
         except KeyError:
             msger.error("bootimg-efi requires a loader, none specified")
-
-        # Auto startup for /EFI/BOOT/boot*.efi
-        bootfiles = glob.glob('%s/EFI/BOOT/boot*.efi' % hdddir)
-        if bootfiles and len(bootfiles) == 1:
-            with open('%s/startup.nsh' % hdddir, 'w') as f:
-                f.write('fs0:\\EFI\\BOOT\\%s\n' % os.path.basename(bootfiles[0]))
 
         du_cmd = "du -bks %s" % hdddir
         out = exec_cmd(du_cmd)


### PR DESCRIPTION
This drops our previous implementation in favor of the one which was submitted to oe-core after rework per [yocto bug 9556](https://bugzilla.yoctoproject.org/show_bug.cgi?id=9556). Once that's merged, it'll be one less thing we need in our poky fork.