### PR TITLE
buildhistory: fix latest_srcrev in the common case

### DIFF
--- a/meta/classes/buildhistory.bbclass
+++ b/meta/classes/buildhistory.bbclass
@@ -833,7 +833,7 @@ python write_srcrev() {
                         f.write('# SRCREV_%s = "%s"\n' % (name, orig_srcrev))
                     f.write('SRCREV_%s = "%s"\n' % (name, srcrev))
             else:
-                f.write('SRCREV = "%s"\n' % srcrevs.values())
+                f.write('SRCREV = "%s"\n' % next(iter(srcrevs.values())))
             if len(tag_srcrevs) > 0:
                 for name, srcrev in tag_srcrevs.items():
                     f.write('# tag_%s = "%s"\n' % (name, srcrev))


### PR DESCRIPTION
buildhistory was writing srcrevs.values() as SRCREV when only one
srcrev/branch exists. This returns a view of the dictionary values in python
3, and used to return a list in python 2, neither of which is an appropriate
value for SRCREV. It was resulting in latest_srcrev files like this:

```
# SRCREV = "346584bf6e38232be8773c24fd7dedcbd7b3d9ed"
SRCREV = "dict_values(['346584bf6e38232be8773c24fd7dedcbd7b3d9ed'])"
```

Which in turn would result in invalid output in buildhistory-collect-srcrevs.
Fix by calling `next(iter())` on the `.values()`

Signed-off-by: Christopher Larson chris_larson@mentor.com
