### PR TITLE
toaster: change to help image customization work for non git layers

### DIFF
--- a/bitbake/lib/toaster/bldcontrol/localhostbecontroller.py
+++ b/bitbake/lib/toaster/bldcontrol/localhostbecontroller.py
@@ -249,13 +249,22 @@ class LocalhostBEController(BuildEnvironmentController):
             br_layer_base_recipe = layers.get(
                 layer_version=customrecipe.base_recipe.layer_version)
 
-            br_layer_base_dirpath = \
-                    os.path.join(self.be.sourcedir,
-                                 self.getGitCloneDirectory(
-                                     br_layer_base_recipe.giturl,
-                                     br_layer_base_recipe.commit),
-                                 customrecipe.base_recipe.layer_version.dirpath
-                                )
+            # If the layer is git cloned we know where it lives
+            if br_layer_base_recipe.giturl and br_layer_base_recipe.commit:
+                layer_path = self.getGitCloneDirectory(
+                                  br_layer_base_recipe.giturl,
+                                  br_layer_base_recipe.commit)
+            # Otherwise we know its a local layer
+            elif br_layer_base_recipe.local_source_dir:
+                layer_path = br_layer_base_recipe.local_source_dir
+            else:
+                logger.error("Unable to workout the dir path for the custom"
+                             " image recipe")
+
+            br_layer_base_dirpath = os.path.join(
+                                    self.be.sourcedir,
+                                    layer_path,
+                                    customrecipe.base_recipe.layer_version.dirpath)
 
             customrecipe.base_recipe.layer_version.dirpath = \
                          br_layer_base_dirpath
@@ -270,6 +279,8 @@ class LocalhostBEController(BuildEnvironmentController):
 
             # Update the layer and recipe objects
             customrecipe.layer_version.dirpath = layerpath
+            customrecipe.layer_version.layer.local_source_dir = layerpath
+            customrecipe.layer_version.layer.save()
             customrecipe.layer_version.save()
 
             customrecipe.file_path = recipe_path


### PR DESCRIPTION
This change will help users use image customization for non git
layers. A part of the change is already submitted upstream, which
I am trying to follow up. Below is the link for the same:

https://lists.yoctoproject.org/pipermail/toaster/2016-October/005241.html

Once this patch gets merged we can safely revert our change.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>