### PR TITLE
buildhistory-collect-srcrevs: write an srcrev when named, not None

### DIFF
--- a/scripts/buildhistory-collect-srcrevs
+++ b/scripts/buildhistory-collect-srcrevs
@@ -101,7 +101,7 @@ def main():
                 for name, value in srcrevs.items():
                     orig = orig_srcrevs.get(name, orig_srcrev)
                     if options.reportall or value != orig:
-                        all_srcrevs[curdir].append((pn, name, srcrev))
+                        all_srcrevs[curdir].append((pn, name, value))
 
     for curdir, srcrevs in sorted(all_srcrevs.items()):
         if srcrevs:


### PR DESCRIPTION
The script was writing the main 'SRCREV' value for SRCREV_name, not the value
of the latter. In the case of recipes without 'SRCREV', like linux-yocto, it
was writing an srcrev of 'None' for all of them.

This has been submitted to oe-core.

JIRA: SB-8304