### PR TITLE
sysroot-relativelinks: also consider links to dirs on the host

### DIFF
--- a/scripts/sysroot-relativelinks.py
+++ b/scripts/sysroot-relativelinks.py
@@ -24,7 +24,7 @@ def handlelink(filep, subdir):
     os.symlink(os.path.relpath(topdir+link, subdir), filep)
 
 for subdir, dirs, files in os.walk(topdir):
-    for f in files:
+    for f in dirs + files:
         filep = os.path.join(subdir, f)
         if os.path.islink(filep):
             #print("Considering %s" % filep)


### PR DESCRIPTION
Dead symlinks, or symlinks to existing files will show up in 'files' of an
os.walk, but symlinks to existing directories show up in 'dirs', so we need to
consider both.

As one specific example, the symlink from /usr/lib/ssl/certs was left pointing
to /etc/ssl/certs rather than the relative path when the sdk was built on
hosts where the latter exists.

JIRA: SB-8374

Signed-off-by: Christopher Larson <chris_larson@mentor.com>