### PR TITLE
fontcache: fix fonts postinst failed

### DIFF
--- a/meta/classes/fontcache.bbclass
+++ b/meta/classes/fontcache.bbclass
@@ -38,6 +38,10 @@ python () {
 }
 
 python add_fontcache_postinsts() {
+    baselib = d.getVar('BASE_LIB_tune-' + (d.getVar('DEFAULTTUNE', True) or 'INVALID'), True) or \
+              d.getVar('BASELIB', True)
+    d.setVar("baselib", baselib)
+
     for pkg in d.getVar('FONT_PACKAGES', True).split():
         bb.note("adding fonts postinst and postrm scripts to %s" % pkg)
         postinst = d.getVar('pkg_postinst_%s' % pkg, True) or d.getVar('pkg_postinst', True)


### PR DESCRIPTION
While instal liberation-fonts to image, the fonts postinst
failed at do_rootfs time:
-----------------------------------------------
|WARNING: core-image-minimal-1.0-r0 do_rootfs: The postinstall intercept hook
'update_font_cache' failed (exit code: 139)! See log for details!
|WARNING: core-image-minimal-1.0-r0 do_rootfs: The postinstalls for the
following packages will be postponed for first boot: liberation-fonts
-----------------------------------------------

Since the following commit applied in oe-core
-----------------------------------------------
commit ce1e7fcc60276040477c1d5e3129e029bb9f204b
Author: Richard Purdie <richard.purdie at linuxfoundation.org>
Date:   Fri Sep 30 17:43:23 2016 +0100

    allarch: Fixes to stop rebuilds when change multilibs
-----------------------------------------------
It assignes base_libdir="/none" which caused fonts postinst failed at
do_rootfs.

The fonts postinst invoke qemu to update font cache which requires
base_libdir arch relative(such as base_libdir="/lib64").

We refer what meta/conf/multilib.conf does, assign it with arch relative.

Signed-off-by: Hongxu Jia <hongxu.jia at windriver.com>