### PR TITLE
bitbake: Replace deprecated git branch parameter "--set-upstream"

### DIFF
--- a/bitbake/lib/bb/fetch2/git.py
+++ b/bitbake/lib/bb/fetch2/git.py
@@ -477,7 +477,7 @@ class Git(FetchMethod):
                 branchname =  ud.branches[ud.names[0]]
                 runfetchcmd("%s checkout -B %s %s" % (ud.basecmd, branchname, \
                             ud.revisions[ud.names[0]]), d, workdir=destdir)
-                runfetchcmd("%s branch --set-upstream %s origin/%s" % (ud.basecmd, branchname, \
+                runfetchcmd("%s branch %s --set-upstream-to origin/%s" % (ud.basecmd, branchname, \
                             branchname), d, workdir=destdir)
             else:
                 runfetchcmd("%s checkout %s" % (ud.basecmd, ud.revisions[ud.names[0]]), d, workdir=destdir)


### PR DESCRIPTION
This is a cherry-pick of
http://cgit.openembedded.org/bitbake/commit/?id=2ab50074c1a6c56a8a178755de108447d7b7acaf
and was reported by a customer under INTAMDDET-2269.